### PR TITLE
Report context cancelation as non-error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,9 @@
 package otgrpc
 
 import (
+	"context"
+	"errors"
+
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"google.golang.org/grpc/codes"
@@ -57,6 +60,9 @@ func SetSpanTags(span opentracing.Span, err error, client bool) {
 	code := codes.Unknown
 	if s, ok := status.FromError(err); ok {
 		code = s.Code()
+	} else if errors.Is(err, context.Canceled) {
+		code = codes.Canceled
+		err = nil // Someone else canceled this operation - we should not flag it as an error.
 	}
 	span.SetTag("response_code", code)
 	span.SetTag("response_class", c)

--- a/errors.go
+++ b/errors.go
@@ -62,6 +62,8 @@ func SetSpanTags(span opentracing.Span, err error, client bool) {
 		code = s.Code()
 	} else if errors.Is(err, context.Canceled) {
 		code = codes.Canceled
+	}
+	if code == codes.Canceled {
 		err = nil // Someone else canceled this operation - we should not flag it as an error.
 	}
 	span.SetTag("response_code", code)

--- a/test/interceptor_test.go
+++ b/test/interceptor_test.go
@@ -1,6 +1,7 @@
 package interceptor_test
 
 import (
+	"fmt"
 	"io"
 	"net"
 	"testing"
@@ -9,8 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"context"
+
 	testpb "github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc/test/otgrpc_testing"
-	"github.com/opentracing-contrib/go-grpc"
+	otgrpc "github.com/opentracing-contrib/go-grpc"
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"google.golang.org/grpc"
 )
@@ -268,5 +270,6 @@ func TestStreamingContextCancellationOpenTracing(t *testing.T) {
 	parent := spans[0]
 	child := spans[1]
 	assert.Equal(t, child.ParentID, parent.Context().(mocktracer.MockSpanContext).SpanID)
-	assert.True(t, parent.Tag("error").(bool))
+	assert.Equal(t, fmt.Sprint(parent.Tag("response_code")), "Canceled")
+	assert.Nil(t, parent.Tag("error"))
 }


### PR DESCRIPTION
Someone else canceled this operation; we should not flag it as an error.

Example of a span flagged as an error when the operation was cancelled as un-needed:
![image](https://user-images.githubusercontent.com/8125524/134396999-d278891a-9564-4c30-a1a8-a8576f1a4baa.png)

Copied from https://github.com/opentracing-contrib/go-grpc/pull/13